### PR TITLE
Minor update in the readme of basic example 🙃

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -56,5 +56,5 @@ mdl serve goa.design/model/examples/basic/model
 Open the diagram in a browser:
 
 ```bash
-open http://localhost:6070/SystemContext
+open http://localhost:8080
 ```


### PR DESCRIPTION
- Currently in the readme of basic example, when the server 
is started it says to `open http://localhost:6070/SystemContext` 
in browser

- But when we run the `mdl serve` command to serve graphical
 editor, the server starts at `http://localhost:8080`. 

Signed-off-by: Puneet Punamiya ppunamiy@redhat.com