### PR TITLE
Properly handle duplicate relationship declarations

### DIFF
--- a/dsl/relationship.go
+++ b/dsl/relationship.go
@@ -337,6 +337,12 @@ func addrel(src *expr.Element, dest any, desc string, args ...any) error {
 		eval.Execute(dsl, rel)
 	}
 	expr.Identify(rel)
+	for _, r := range src.Relationships {
+		if r.ID == rel.ID {
+			// relationship could have been imported from another DSL, valid to have duplicates
+			return nil
+		}
+	}
 	src.Relationships = append(src.Relationships, rel)
 
 	return nil


### PR DESCRIPTION
This can happen when a model package imports others that define the same relationship.

The code would create a duplicate entry in the registry and in the source relationships. This duplicate could have an unresolved destination causing a panic downstream.