### PR TITLE
Fix linting issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cmd/mdl/webapp/dist-static
 .vscode
 
 
+cover.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+linters:
+  exclusions:
+    rules:
+      - linters:
+          - staticcheck
+        text: "ST1001"

--- a/codegen/json.go
+++ b/codegen/json.go
@@ -30,7 +30,11 @@ func JSON(pkg string, debug bool) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() { os.RemoveAll(tmpDir) }()
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to remove temp dir: %v\n", err)
+		}
+	}()
 	var sections []*codegen.SectionTemplate
 	{
 		imports := []*codegen.ImportSpec{

--- a/expr/render.go
+++ b/expr/render.go
@@ -232,9 +232,10 @@ func addAnimationStepRelationships(vp *ViewProps) {
 		for _, rv := range vp.RelationshipViews {
 			for _, eh := range s.Elements {
 				id := eh.GetElement().ID
-				if id == rv.Source.ID {
+				switch id {
+				case rv.Source.ID:
 					oldSrc = true
-				} else if id == rv.Destination.ID {
+				case rv.Destination.ID:
 					oldDest = true
 				}
 				if oldSrc && oldDest {
@@ -245,9 +246,10 @@ func addAnimationStepRelationships(vp *ViewProps) {
 				break
 			}
 			for _, ev := range vp.ElementViews {
-				if ev.Element.ID == rv.Source.ID {
+				switch ev.Element.ID {
+				case rv.Source.ID:
 					newSrc = true
-				} else if ev.Element.ID == rv.Destination.ID {
+				case rv.Destination.ID:
 					newDest = true
 				}
 				if newSrc && newDest {

--- a/expr/render_test.go
+++ b/expr/render_test.go
@@ -352,8 +352,8 @@ func Test_CoalesceRelationships(t *testing.T) {
 		coalescedRel := Registry[coalescedView.RelationshipID].(*Relationship)
 
 		// Verify source and destination are correct
-		assert.Equal(t, mSource.Element.ID, coalescedRel.Source.ID, "Source should match")
-		assert.Equal(t, mDestination.Element.ID, coalescedRel.Destination.ID, "Destination should match")
+		assert.Equal(t, mSource.ID, coalescedRel.Source.ID, "Source should match")
+		assert.Equal(t, mDestination.ID, coalescedRel.Destination.ID, "Destination should match")
 	})
 }
 
@@ -395,7 +395,7 @@ func Test_CoalesceAllRelationshipsInView(t *testing.T) {
 		copy(viewProps.RelationshipViews, baseViewProps.RelationshipViews)
 
 		explicitPairs := make(map[string]bool)
-		explicitPairs[mSource.Element.ID+"->"+mDestination.Element.ID] = true
+		explicitPairs[mSource.ID+"->"+mDestination.ID] = true
 
 		initialCount := len(viewProps.RelationshipViews)
 		assert.Equal(t, 2, initialCount, "Should start with 2 relationship views")

--- a/expr/views_test.go
+++ b/expr/views_test.go
@@ -538,7 +538,7 @@ func Test_AddDeploymentNodeChildren(t *testing.T) {
 	}
 	dv := DeploymentView{
 		ViewProps:        &mViewProps,
-		SoftwareSystemID: mSoftwareSystem.Element.ID,
+		SoftwareSystemID: mSoftwareSystem.ID,
 	}
 	tests := []struct {
 		dv1  *DeploymentView

--- a/mdl/eval.go
+++ b/mdl/eval.go
@@ -121,12 +121,12 @@ func ModelizeDesign(d *expr.Design) *Design {
 
 func modelizePerson(p *expr.Person) *Person {
 	return &Person{
-		ID:            p.Element.ID,
-		Name:          p.Element.Name,
-		Description:   p.Element.Description,
-		Tags:          p.Element.Tags,
-		URL:           p.Element.URL,
-		Properties:    p.Element.Properties,
+		ID:            p.ID,
+		Name:          p.Name,
+		Description:   p.Description,
+		Tags:          p.Tags,
+		URL:           p.URL,
+		Properties:    p.Properties,
 		Relationships: modelizeRelationships(p.Relationships),
 		Location:      LocationKind(p.Location),
 	}

--- a/stz/client.go
+++ b/stz/client.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"os/user"
 	"strconv"
 	"time"
@@ -74,7 +75,11 @@ func (c *Client) Get(id string) (*Workspace, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+		}
+	}()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("service error: %s", string(body))
@@ -97,7 +102,11 @@ func (c *Client) Put(id string, w *Workspace) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+		}
+	}()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("service error: %s", string(body))
@@ -139,7 +148,11 @@ func (c *Client) lockUnlock(id string, lock bool) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		var res Response


### PR DESCRIPTION
- Updated `.gitignore` to include `cover.out`.
- Added a new `.golangci.yml` configuration file for linter settings.
- Improved error handling in `main.go`, `json.go`, `client.go`, and other files by logging errors when closing files and removing temporary directories.
- Refactored tests in `render_test.go` and `views_test.go` to use direct IDs instead of nested element IDs for better clarity and accuracy.
- Updated `eval.go` to directly reference properties of `Person` instead of accessing them through `Element`.