### PR TITLE
Fixed rectangle render 

### DIFF
--- a/cmd/mdl/webapp/src/graph-view/shapes.ts
+++ b/cmd/mdl/webapp/src/graph-view/shapes.ts
@@ -347,7 +347,7 @@ function webbrowser(parent: D3Element, bbox: BBox, node: D3Node) {
 }
 
 export const shapes: { [key: string]: (parent: SVGElement, node: D3Node) => SVGElement } = {
-	box: (parent: SVGElement, node: D3Node) => rect(new D3Element(parent), node, node).node(),
+	rectangle: (parent: SVGElement, node: D3Node) => rect(new D3Element(parent), node, node).node(),
 	roundedbox: (parent: SVGElement, node: D3Node) => rect(new D3Element(parent), node, node, true).node(),
 	component: (parent: SVGElement, node: D3Node) => component(new D3Element(parent), node, node).node(),
 	cylinder: (parent: SVGElement, node: D3Node) => cylinder(new D3Element(parent), node, node).node(),


### PR DESCRIPTION
Current version of mdl web ui in main branch breaks on start.
To reproduce, just launch it with example from readme:
```
mdl serve goa.design/model/examples/basic/model -dir gen
```

This happens because there's no such shape function as rectangle in `shapes` array, instead there is old `box` shape function. 
Renamed it to `rectangle` to fix webapp.