### PR TITLE
Release v1.16.8

### DIFF
--- a/DSL.md
+++ b/DSL.md
@@ -3,7 +3,7 @@
 
 The code snippet below describes the entire syntax of the DSL. The complete
 reference can be found in the `dsl`
-[package documentation](https://pkg.go.dev/goa.design/model@v1.16.7/dsl?tab=doc)
+[package documentation](https://pkg.go.dev/goa.design/model@v1.16.8/dsl?tab=doc)
 
 ```Go
 // Design defines the architecture design containing the models and views.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #
 MAJOR=1
 MINOR=16
-BUILD=7
+BUILD=8
 
 GO_FILES=$(shell find . -path './cmd/mdl/webapp/node_modules' -prune -o -type f -name '*.go' -print)
 GO_DIRS=$(shell go list -f '{{.Dir}}' ./... | grep -v '/cmd/mdl/webapp/node_modules/')

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ under the current path. For example:
 ```bash
 mdl serve goa.design/model/examples/basic/model -dir gen
 Watching: /home/raphael/go/src/goa.design/model/examples/basic/model
-mdl v1.16.7, editor started. Open http://localhost:8080 in your browser.
+mdl v1.16.8, editor started. Open http://localhost:8080 in your browser.
 ```
 
 Modifying and saving the DSL while the editor is running causes it to
@@ -244,13 +244,13 @@ in this repo.
 
 ### Using Model as a library
 
-The [mdl](https://pkg.go.dev/goa.design/model@v1.16.7/mdl?tab=doc) package
-[RunDSL](https://pkg.go.dev/goa.design/model@v1.16.7/mdl?tab=doc#RunDSL)
+The [mdl](https://pkg.go.dev/goa.design/model@v1.16.8/mdl?tab=doc) package
+[RunDSL](https://pkg.go.dev/goa.design/model@v1.16.8/mdl?tab=doc#RunDSL)
 method runs the DSL and produces data structures that contain all the
 information needed to render the views it defines.
 
-The [stz](https://pkg.go.dev/goa.design/model@v1.16.7/stz?tab=doc) package
-[RunDSL](https://pkg.go.dev/goa.design/model@v1.16.7/stz?tab=doc#RunDSL)
+The [stz](https://pkg.go.dev/goa.design/model@v1.16.8/stz?tab=doc) package
+[RunDSL](https://pkg.go.dev/goa.design/model@v1.16.8/stz?tab=doc#RunDSL)
 method runs the DSL and produces a data structure that can be serialized into
 JSON and uploaded to the [Structurizr service](https://structurizr.com).
 
@@ -379,7 +379,7 @@ view that is scoped to a parent element.
 ### Resources
 
 The DSL package
-[documentation](https://pkg.go.dev/goa.design/model@v1.16.7/dsl?tab=doc) lists
+[documentation](https://pkg.go.dev/goa.design/model@v1.16.8/dsl?tab=doc) lists
 all the DSL keywords and their usage.
 
 The file [DSL.md](https://github.com/goadesign/model/blob/master/DSL.md)

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -10,7 +10,7 @@ const (
 	// Minor version number
 	Minor = 16
 	// Build number
-	Build = 7
+	Build = 8
 	// Suffix - set to empty string in release tag commits.
 	Suffix = ""
 )


### PR DESCRIPTION
## Summary

Release Model v1.16.8 with the headless SVG export fix from #1135. Standalone diagrams now include the SVG definitions needed to display relationship arrowheads.

The release commit updates the build number and versioned documentation links. It does not change diagram source files or regenerate consumer diagrams.

## Validation

- Arrowhead fix passed dependency review, lint, and the full test suite in #1135.
- `go test ./pkg/...`
- Confirmed the release diff contains only version and documentation references.

## Review guide

Verify that the version is consistently `1.16.8` in the build constants and documentation. The rendering behavior is reviewed separately in #1135.